### PR TITLE
Fix query string bug

### DIFF
--- a/libs/placeholders/query.js
+++ b/libs/placeholders/query.js
@@ -1,5 +1,5 @@
 var parseRequest = require('../parseRequest');
 
 module.exports = function(req) {
-  return parseRequest(req).search;
+  return parseRequest(req).search || '';
 };

--- a/test/specs/placeholders/query.tests.js
+++ b/test/specs/placeholders/query.tests.js
@@ -22,6 +22,17 @@ describe('The query placeholder', function() {
     });
   });
 
+  it('handles empty query strings', function(done) {
+    var rule = { from: /.*/, to: '/error{query}' };
+    var opts = { url: 'http://localhost:51789/something/' };
+    app.verifyRules(rule, opts, function(err, res) {
+      expect(err).to.not.exist;
+      expect(res.statusCode).to.equal(301);
+      expect(res.headers.location).to.equal('/error');
+      done();
+    });
+  });
+
   after(function(done) {
     app.stop(done);
   });


### PR DESCRIPTION
If a URL does not contain a query string, then the `{query}` placeholder erroneoulsy outputs as `null` instead of being blank.